### PR TITLE
HelpCommand only returns first name

### DIFF
--- a/src/Command.js
+++ b/src/Command.js
@@ -39,10 +39,8 @@ class Command {
     static usage = '';
 
     /**
-     * Commands
-     * It's advised to set the main name first on
-     * the array as this is the one that will
-     * appear when using the Help command.
+     * The primary command name followed by possible aliases.
+     * Only the primary name is used in slash commands and the help command.
      * @type {String[]}
      */
     static names = [];

--- a/src/Command.js
+++ b/src/Command.js
@@ -39,7 +39,10 @@ class Command {
     static usage = '';
 
     /**
-     * commands
+     * Commands
+     * It's advised to set the main name first on
+     * the array as this is the one that will
+     * appear when using the Help command.
      * @type {String[]}
      */
     static names = [];

--- a/src/commands/utility/HelpCommand.js
+++ b/src/commands/utility/HelpCommand.js
@@ -23,7 +23,7 @@ class HelpCommand extends Command {
                 .setFooter(`View a command or category using ${this.prefix}help <category|command>`);
             for (const [key, commands] of categories.entries()) {
                 if (commands.length === 0) continue;
-                embed.addField(util.toTitleCase(key), commands.map(c => c.names).flat().sort().join(', '));
+                embed.addField(util.toTitleCase(key), commands.map(c => c.names[0]).flat().sort().join(', '));
             }
             return this.reply(embed);
         }


### PR DESCRIPTION
This makes it look less cluttered, though command names array should now begin with the main name of the command.