### PR TITLE
Automatically set static images to be a .png

### DIFF
--- a/src/commands/utility/AvatarCommand.js
+++ b/src/commands/utility/AvatarCommand.js
@@ -22,7 +22,7 @@ class AvatarCommand extends Command{
 
         const avatarEmbed = new MessageEmbed()
             .setTitle(`Avatar of ${util.escapeFormatting(user.tag)}`)
-            .setImage(user.displayAvatarURL({dynamic: true, size: 2048}))
+            .setImage(user.displayAvatarURL({dynamic: true, size: 2048, format: png}))
             .setFooter(`Command executed by ${util.escapeFormatting(this.source.getUser().tag)}`)
             .setTimestamp();
 


### PR DESCRIPTION
This fixes the issue where files dont have any proper filetype, which is rather annoying when downloading something from the avatar command.