### PR TITLE
SendUsage if no args specified with set

### DIFF
--- a/src/commands/settings/SpamProtectionCommand.js
+++ b/src/commands/settings/SpamProtectionCommand.js
@@ -35,7 +35,12 @@ class SetSpamProtectionCommand extends SetConfigCommand {
         const count = this.options.getInteger('value');
         if (count < 1 || count > 60) {
             await this.sendUsage();
-        } else {
+        }
+        if (!this.args.length) {
+            await this.sendUsage();
+            return;
+        }
+        else {
             this.guildConfig.antiSpam = count;
             await this.guildConfig.save();
             await this.reply(`Enabled spam protection! Users can now only send ${count} messages per minute.`);

--- a/src/commands/settings/SpamProtectionCommand.js
+++ b/src/commands/settings/SpamProtectionCommand.js
@@ -33,14 +33,10 @@ class SetSpamProtectionCommand extends SetConfigCommand {
 
     async execute() {
         const count = this.options.getInteger('value');
-        if (count < 1 || count > 60) {
-            await this.sendUsage();
-        }
-        if (!this.args.length) {
+        if (!count || count < 1 || count > 60) {
             await this.sendUsage();
             return;
-        }
-        else {
+        } else {
             this.guildConfig.antiSpam = count;
             await this.guildConfig.save();
             await this.reply(`Enabled spam protection! Users can now only send ${count} messages per minute.`);


### PR DESCRIPTION
This *should* stop it from setting the spamprotection to NaN messages per minute, as it currently does