### PR TITLE
Improve editing bad-words and auto-responses

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,8 +25,8 @@
     "@google-cloud/vision": "^3.0.1",
     "@googleapis/youtube": "^6.0.0",
     "diff": "^5.1.0",
-    "discord-api-types": "^0.37.12",
-    "discord.js": "^14.6.0",
+    "discord-api-types": "^0.37.20",
+    "discord.js": "^14.7.1",
     "fuse.js": "^6.6.2",
     "got": "^12.5.1",
     "mysql2": "^2.3.3",
@@ -36,7 +36,7 @@
   "devDependencies": {
     "@types/node": "^18.8.3",
     "eslint": "^8.25.0",
-    "eslint-plugin-jsdoc": "^39.3.6",
+    "eslint-plugin-jsdoc": "^39.6.4",
     "eslint-plugin-json": "^3.1.0"
   },
   "lint-staged": {

--- a/src/commands/CommandManager.js
+++ b/src/commands/CommandManager.js
@@ -347,7 +347,7 @@ export class CommandManager {
     }
 
     /**
-     * @param {import('discord.js').SelectMenuInteraction} interaction
+     * @param {import('discord.js').AnySelectMenuInteraction} interaction
      * @return {Promise<void>}
      */
     async executeSelectMenu(interaction) {

--- a/src/commands/ExecutableCommand.js
+++ b/src/commands/ExecutableCommand.js
@@ -83,7 +83,7 @@ export default class ExecutableCommand {
 
     /**
      * handle data submitted from a modal
-     * @param {import('discord.js').SelectMenuInteraction} interaction
+     * @param {import('discord.js').AnySelectMenuInteraction} interaction
      * @return {Promise<void>}
      */
     async executeSelectMenu(interaction) {

--- a/src/commands/external/ArticleCommand.js
+++ b/src/commands/external/ArticleCommand.js
@@ -8,7 +8,8 @@ import {
     codeBlock,
     EmbedBuilder,
     escapeBold,
-    SelectMenuBuilder, userMention,
+    StringSelectMenuBuilder,
+    userMention,
 } from 'discord.js';
 import Turndown from 'turndown';
 import icons from '../../util/icons.js';
@@ -137,7 +138,7 @@ export default class ArticleCommand extends Command {
             components: [
                 new ActionRowBuilder()
                     .addComponents(
-                        /** @type {any} */ new SelectMenuBuilder()
+                        /** @type {any} */ new StringSelectMenuBuilder()
                             .setOptions(/** @type {any} */ results)
                             .setCustomId(`article:${userId}` + (mention ? `:${mention}` : ''))
                     ),

--- a/src/commands/external/VideoCommand.js
+++ b/src/commands/external/VideoCommand.js
@@ -2,7 +2,7 @@ import Command from '../Command.js';
 import GuildSettings from '../../settings/GuildSettings.js';
 import {SELECT_MENU_TITLE_LIMIT} from '../../util/apiLimits.js';
 import icons from '../../util/icons.js';
-import {ActionRowBuilder, SelectMenuBuilder, userMention} from 'discord.js';
+import {ActionRowBuilder, StringSelectMenuBuilder, userMention} from 'discord.js';
 import ErrorEmbed from '../../embeds/ErrorEmbed.js';
 import config from '../../bot/Config.js';
 import {componentEmojiIfExists} from '../../util/format.js';
@@ -111,7 +111,7 @@ export default class VideoCommand extends Command {
             components: [
                 new ActionRowBuilder()
                     .addComponents(
-                        /** @type {any} */ new SelectMenuBuilder()
+                        /** @type {any} */ new StringSelectMenuBuilder()
                             .setOptions(/** @type {any} */ videos)
                             .setCustomId(`video:${userId}` + (mention ? `:${mention}` : ''))
                     ),

--- a/src/commands/settings/auto-response/AddAutoResponseCommand.js
+++ b/src/commands/settings/auto-response/AddAutoResponseCommand.js
@@ -1,12 +1,18 @@
 import SubCommand from '../../SubCommand.js';
-import {ActionRowBuilder, ModalBuilder, TextInputBuilder, TextInputStyle} from 'discord.js';
+import {
+    ActionRowBuilder,
+    ChannelSelectMenuBuilder,
+    ChannelType,
+    ModalBuilder,
+    TextInputBuilder,
+    TextInputStyle
+} from 'discord.js';
 import Confirmation from '../../../database/Confirmation.js';
 import {timeAfter} from '../../../util/timeutils.js';
 import AutoResponse from '../../../database/AutoResponse.js';
 import ErrorEmbed from '../../../embeds/ErrorEmbed.js';
-import ChannelWrapper from '../../../discord/ChannelWrapper.js';
-import {channelSelectMenu} from '../../../util/channels.js';
 import colors from '../../../util/colors.js';
+import {SELECT_MENU_OPTIONS_LIMIT} from '../../../util/apiLimits.js';
 
 export default class AddAutoResponseCommand extends SubCommand {
 
@@ -110,17 +116,22 @@ export default class AddAutoResponseCommand extends SubCommand {
             confirmation.data.trigger = trigger;
             confirmation.data.response = response;
             confirmation.expires = timeAfter('30 min');
-            const channels = (await interaction.guild.channels.fetch())
-                .map(channel => new ChannelWrapper(channel));
 
             await interaction.reply({
                 ephemeral: true,
                 content: 'Select channels for the auto-response',
                 components: [
                     /** @type {ActionRowBuilder} */
-                    new ActionRowBuilder().addComponents(/** @type {*} */
-                        channelSelectMenu(channels)
-                            .setCustomId(`auto-response:add:${await confirmation.save()}`)
+                    new ActionRowBuilder().addComponents(/** @type {*} */new ChannelSelectMenuBuilder()
+                        .addChannelTypes(/** @type {*} */[
+                            ChannelType.GuildText,
+                            ChannelType.GuildForum,
+                            ChannelType.GuildAnnouncement,
+                            ChannelType.GuildStageVoice,
+                        ])
+                        .setMinValues(1)
+                        .setMaxValues(SELECT_MENU_OPTIONS_LIMIT)
+                        .setCustomId(`auto-response:add:${await confirmation.save()}`)
                     ),
                 ]
             });

--- a/src/commands/settings/auto-response/EditAutoResponseCommand.js
+++ b/src/commands/settings/auto-response/EditAutoResponseCommand.js
@@ -85,6 +85,11 @@ export default class EditAutoResponseCommand extends CompletingAutoResponseComma
         global ??= autoResponse.global;
         type ??= autoResponse.trigger.type;
 
+        let trigger = autoResponse.trigger;
+        if (type === 'regex') {
+            trigger = trigger.toRegex();
+        }
+
         const confirmation = new Confirmation({global, type, id: autoResponse.id}, timeAfter('1 hour'));
         await interaction.showModal(new ModalBuilder()
             .setTitle(`Edit Auto-response #${autoResponse.id}`)
@@ -100,7 +105,7 @@ export default class EditAutoResponseCommand extends CompletingAutoResponseComma
                             .setStyle(TextInputStyle.Short)
                             .setPlaceholder(AutoResponse.getTriggerPlaceholder(type))
                             .setLabel('Trigger')
-                            .setValue(autoResponse.trigger.asContentString()),
+                            .setValue(trigger.asContentString()),
                     ),
                 /** @type {*} */
                 new ActionRowBuilder()

--- a/src/commands/settings/auto-response/EditAutoResponseCommand.js
+++ b/src/commands/settings/auto-response/EditAutoResponseCommand.js
@@ -1,12 +1,19 @@
 import CompletingAutoResponseCommand from './CompletingAutoResponseCommand.js';
 import Confirmation from '../../../database/Confirmation.js';
 import {timeAfter} from '../../../util/timeutils.js';
-import {ActionRowBuilder, ModalBuilder, TextInputBuilder, TextInputStyle} from 'discord.js';
+import {
+    ActionRowBuilder,
+    channelMention,
+    ChannelSelectMenuBuilder,
+    ChannelType,
+    ModalBuilder,
+    TextInputBuilder,
+    TextInputStyle
+} from 'discord.js';
 import AutoResponse from '../../../database/AutoResponse.js';
 import ErrorEmbed from '../../../embeds/ErrorEmbed.js';
-import ChannelWrapper from '../../../discord/ChannelWrapper.js';
-import {channelSelectMenu} from '../../../util/channels.js';
 import colors from '../../../util/colors.js';
+import {SELECT_MENU_OPTIONS_LIMIT} from '../../../util/apiLimits.js';
 
 export default class EditAutoResponseCommand extends CompletingAutoResponseCommand {
 
@@ -154,23 +161,23 @@ export default class EditAutoResponseCommand extends CompletingAutoResponseComma
             confirmation.data.trigger = trigger;
             confirmation.data.response = response;
             confirmation.expires = timeAfter('30 min');
-            const channels = (await interaction.guild.channels.fetch())
-                .map(channel => new ChannelWrapper(channel));
 
             await interaction.reply({
                 ephemeral: true,
-                content: 'Select channels for the auto-response',
+                content: `Select channels for the auto-response. Currently selected channels: ${
+                    autoResponse.channels.map(c => channelMention(c)).join(', ')}`,
                 components: [
                     /** @type {ActionRowBuilder} */
-                    new ActionRowBuilder().addComponents(/** @type {*} */
-                        channelSelectMenu(channels, autoResponse.channels)
-                            .setCustomId('noop')
-                            .setDisabled(true)
-                    ),
-                    /** @type {ActionRowBuilder} */
-                    new ActionRowBuilder().addComponents(/** @type {*} */
-                        channelSelectMenu(channels)
-                            .setCustomId(`auto-response:edit:${await confirmation.save()}`)
+                    new ActionRowBuilder().addComponents(/** @type {*} */new ChannelSelectMenuBuilder()
+                        .addChannelTypes(/** @type {*} */[
+                            ChannelType.GuildText,
+                            ChannelType.GuildForum,
+                            ChannelType.GuildAnnouncement,
+                            ChannelType.GuildStageVoice,
+                        ])
+                        .setMinValues(1)
+                        .setMaxValues(SELECT_MENU_OPTIONS_LIMIT)
+                        .setCustomId(`auto-response:edit:${await confirmation.save()}`)
                     )
                 ]
             });

--- a/src/commands/settings/bad-word/AddBadWordCommand.js
+++ b/src/commands/settings/bad-word/AddBadWordCommand.js
@@ -1,12 +1,18 @@
-import {ActionRowBuilder, ModalBuilder, TextInputBuilder, TextInputStyle} from 'discord.js';
+import {
+    ActionRowBuilder,
+    ChannelSelectMenuBuilder,
+    ChannelType,
+    ModalBuilder,
+    TextInputBuilder,
+    TextInputStyle
+} from 'discord.js';
 import Confirmation from '../../../database/Confirmation.js';
 import {parseTime, timeAfter} from '../../../util/timeutils.js';
 import ErrorEmbed from '../../../embeds/ErrorEmbed.js';
-import ChannelWrapper from '../../../discord/ChannelWrapper.js';
-import {channelSelectMenu} from '../../../util/channels.js';
 import colors from '../../../util/colors.js';
 import AddAutoResponseCommand from '../auto-response/AddAutoResponseCommand.js';
 import BadWord from '../../../database/BadWord.js';
+import {SELECT_MENU_OPTIONS_LIMIT} from '../../../util/apiLimits.js';
 
 export default class AddBadWordCommand extends AddAutoResponseCommand {
 
@@ -155,17 +161,21 @@ export default class AddBadWordCommand extends AddAutoResponseCommand {
             confirmation.data.priority = priority;
             confirmation.expires = timeAfter('30 min');
 
-            const channels = (await interaction.guild.channels.fetch())
-                .map(channel => new ChannelWrapper(channel));
-
             await interaction.reply({
                 ephemeral: true,
                 content: 'Select channels for the bad-word',
                 components: [
                     /** @type {ActionRowBuilder} */
-                    new ActionRowBuilder().addComponents(/** @type {*} */
-                        channelSelectMenu(channels)
-                            .setCustomId(`bad-word:add:${await confirmation.save()}`)
+                    new ActionRowBuilder().addComponents(/** @type {*} */new ChannelSelectMenuBuilder()
+                        .addChannelTypes(/** @type {*} */[
+                            ChannelType.GuildText,
+                            ChannelType.GuildForum,
+                            ChannelType.GuildAnnouncement,
+                            ChannelType.GuildStageVoice,
+                        ])
+                        .setMinValues(1)
+                        .setMaxValues(SELECT_MENU_OPTIONS_LIMIT)
+                        .setCustomId(`bad-word:add:${await confirmation.save()}`)
                     ),
                 ]
             });

--- a/src/commands/settings/bad-word/AddBadWordCommand.js
+++ b/src/commands/settings/bad-word/AddBadWordCommand.js
@@ -77,10 +77,13 @@ export default class AddBadWordCommand extends AddAutoResponseCommand {
                     .addComponents(
                         /** @type {*} */
                         new TextInputBuilder()
+                            .setRequired(false)
                             .setCustomId('response')
                             .setStyle(TextInputStyle.Paragraph)
                             .setPlaceholder('Hi there :wave:')
                             .setLabel('Response')
+                            .setMinLength(1)
+                            .setMaxLength(4000)
                     ),
                 /** @type {*} */
                 new ActionRowBuilder()
@@ -92,6 +95,8 @@ export default class AddBadWordCommand extends AddAutoResponseCommand {
                             .setStyle(TextInputStyle.Paragraph)
                             .setPlaceholder('0')
                             .setLabel('Priority')
+                            .setMinLength(1)
+                            .setMaxLength(10)
                     )
             );
 
@@ -102,11 +107,13 @@ export default class AddBadWordCommand extends AddAutoResponseCommand {
                     .addComponents(
                         /** @type {*} */
                         new TextInputBuilder()
-                            .setRequired(true)
+                            .setRequired(false)
                             .setCustomId('duration')
                             .setStyle(TextInputStyle.Short)
                             .setPlaceholder('Punishment duration')
                             .setLabel('duration')
+                            .setMinLength(2)
+                            .setMaxLength(4000)
                     )
             );
         }

--- a/src/commands/settings/bad-word/EditBadWordCommand.js
+++ b/src/commands/settings/bad-word/EditBadWordCommand.js
@@ -238,7 +238,7 @@ export default class EditBadWordCommand extends CompletingBadWordCommand {
                 confirmation.data.type,
                 trigger,
                 response,
-                confirmation.data.punishment,
+                confirmation.data.punishment.action,
                 duration,
                 priority,
             );
@@ -289,7 +289,7 @@ export default class EditBadWordCommand extends CompletingBadWordCommand {
             confirmation.data.type,
             confirmation.data.trigger,
             confirmation.data.response,
-            confirmation.data.punishment,
+            confirmation.data.punishment.action,
             confirmation.data.duration,
             confirmation.data.priority,
         );

--- a/src/commands/settings/bad-word/EditBadWordCommand.js
+++ b/src/commands/settings/bad-word/EditBadWordCommand.js
@@ -147,22 +147,28 @@ export default class EditBadWordCommand extends CompletingBadWordCommand {
                     .addComponents(
                         /** @type {*} */
                         new TextInputBuilder()
+                            .setRequired(false)
                             .setCustomId('response')
                             .setStyle(TextInputStyle.Paragraph)
                             .setPlaceholder('Hi there :wave:')
                             .setLabel('Response')
                             .setValue(badWord.response)
+                            .setMinLength(1)
+                            .setMaxLength(4000)
                     ),
                 /** @type {*} */
                 new ActionRowBuilder()
                     .addComponents(
                         /** @type {*} */
                         new TextInputBuilder()
+                            .setRequired(false)
                             .setCustomId('priority')
                             .setStyle(TextInputStyle.Paragraph)
                             .setPlaceholder('0')
                             .setLabel('Priority')
                             .setValue(badWord.priority.toString())
+                            .setMinLength(1)
+                            .setMaxLength(10)
                     )
             );
 
@@ -173,7 +179,7 @@ export default class EditBadWordCommand extends CompletingBadWordCommand {
                     .addComponents(
                         /** @type {*} */
                         new TextInputBuilder()
-                            .setRequired(true)
+                            .setRequired(false)
                             .setCustomId('duration')
                             .setStyle(TextInputStyle.Short)
                             .setPlaceholder('Punishment duration')

--- a/src/commands/settings/bad-word/EditBadWordCommand.js
+++ b/src/commands/settings/bad-word/EditBadWordCommand.js
@@ -325,7 +325,7 @@ export default class EditBadWordCommand extends CompletingBadWordCommand {
             return interaction.reply(ErrorEmbed.message(triggerResponse.message));
         }
         badWord.trigger = triggerResponse.trigger;
-        badWord.response = response;
+        badWord.response = response || 'disabled';
         badWord.punishment = new Punishment({action: punishment, duration});
         badWord.priority = priority;
         await badWord.save();

--- a/src/commands/settings/bad-word/EditBadWordCommand.js
+++ b/src/commands/settings/bad-word/EditBadWordCommand.js
@@ -122,10 +122,14 @@ export default class EditBadWordCommand extends CompletingBadWordCommand {
     async showModal(interaction, badWord, global, type, punishment) {
         global ??= badWord.global;
         type ??= badWord.trigger.type;
-        punishment ??= badWord.punishment;
+        punishment ??= badWord.punishment.action;
+
+        let trigger = badWord.trigger;
+        if (type === 'regex') {
+            trigger = trigger.toRegex();
+        }
 
         const confirmation = new Confirmation({global, type, id: badWord.id, punishment}, timeAfter('1 hour'));
-
         const modal = new ModalBuilder()
             .setTitle(`Edit Bad-word #${badWord.id}`)
             .setCustomId(`bad-word:edit:${await confirmation.save()}`)
@@ -140,7 +144,7 @@ export default class EditBadWordCommand extends CompletingBadWordCommand {
                             .setStyle(TextInputStyle.Short)
                             .setPlaceholder(BadWord.getTriggerPlaceholder(type))
                             .setLabel('Trigger')
-                            .setValue(badWord.trigger.asContentString()),
+                            .setValue(trigger.asContentString()),
                     ),
                 /** @type {*} */
                 new ActionRowBuilder()
@@ -238,7 +242,7 @@ export default class EditBadWordCommand extends CompletingBadWordCommand {
                 confirmation.data.type,
                 trigger,
                 response,
-                confirmation.data.punishment.action,
+                confirmation.data.punishment,
                 duration,
                 priority,
             );
@@ -289,7 +293,7 @@ export default class EditBadWordCommand extends CompletingBadWordCommand {
             confirmation.data.type,
             confirmation.data.trigger,
             confirmation.data.response,
-            confirmation.data.punishment.action,
+            confirmation.data.punishment,
             confirmation.data.duration,
             confirmation.data.priority,
         );
@@ -304,7 +308,7 @@ export default class EditBadWordCommand extends CompletingBadWordCommand {
      * @param {string} type
      * @param {string} trigger
      * @param {string} response
-     * @param {string} punishment
+     * @param {PunishmentAction} punishment
      * @param {?number} duration
      * @param {number} priority
      * @return {Promise<*>}

--- a/src/commands/settings/bad-word/EditBadWordCommand.js
+++ b/src/commands/settings/bad-word/EditBadWordCommand.js
@@ -265,7 +265,7 @@ export default class EditBadWordCommand extends CompletingBadWordCommand {
                         ])
                         .setMinValues(1)
                         .setMaxValues(SELECT_MENU_OPTIONS_LIMIT)
-                        .setCustomId(`auto-response:edit:${await confirmation.save()}`)
+                        .setCustomId(`bad-word:edit:${await confirmation.save()}`)
                     )
                 ]
             });

--- a/src/database/BadWord.js
+++ b/src/database/BadWord.js
@@ -137,7 +137,7 @@ export default class BadWord extends ChatTriggeredFeature {
             punishment: new Punishment({action: punishment ?? 'none', duration: duration}),
             global,
             channels,
-            response: response ?? 'disabled',
+            response: response || 'disabled',
             priority,
         });
         await badWord.save();

--- a/src/database/Trigger.js
+++ b/src/database/Trigger.js
@@ -1,4 +1,5 @@
 import {inlineCode} from 'discord.js';
+import {escapeRegExp} from '../util/util.js';
 
 export default class Trigger {
     /**
@@ -55,10 +56,10 @@ export default class Trigger {
         let content;
         switch (this.type) {
             case 'include':
-                content = this.content;
+                content = escapeRegExp(this.content);
                 break;
             case 'match':
-                content = `^${this.content}$`;
+                content = `^${escapeRegExp(this.content)}$`;
                 break;
 
             default:

--- a/src/database/Trigger.js
+++ b/src/database/Trigger.js
@@ -45,4 +45,26 @@ export default class Trigger {
             return this.content;
         }
     }
+
+    /**
+     * Convert this trigger to a regex trigger.
+     * This is only supported for include and match types.
+     * @return {Trigger}
+     */
+    toRegex() {
+        let content;
+        switch (this.type) {
+            case 'include':
+                content = this.content;
+                break;
+            case 'match':
+                content = `^${this.content}$`;
+                break;
+
+            default:
+                return this;
+        }
+
+        return  new Trigger({type: 'regex', content, flags: 'i'});
+    }
 }

--- a/src/events/discord/interactionCreate/CommandEventListener.js
+++ b/src/events/discord/interactionCreate/CommandEventListener.js
@@ -5,7 +5,6 @@ import {
     ChatInputCommandInteraction,
     MessageContextMenuCommandInteraction,
     ModalSubmitInteraction,
-    SelectMenuInteraction,
     UserContextMenuCommandInteraction
 } from 'discord.js';
 import commandManager from '../../../commands/CommandManager.js';
@@ -30,8 +29,8 @@ export default class CommandEventListener extends InteractionCreateEventListener
         else if (interaction instanceof ModalSubmitInteraction) {
             await commandManager.executeModal(interaction);
         }
-        else if (interaction instanceof SelectMenuInteraction) {
-            await commandManager.executeSelectMenu(interaction);
+        else if (interaction.isAnySelectMenu()) {
+            await commandManager.executeSelectMenu(/** @type {import('discord.js').AnySelectMenuInteraction} */interaction);
         }
     }
 }

--- a/src/util/channels.js
+++ b/src/util/channels.js
@@ -1,15 +1,13 @@
-import {SelectMenuBuilder} from 'discord.js';
+import {StringSelectMenuBuilder} from 'discord.js';
 import {SELECT_MENU_OPTIONS_LIMIT} from './apiLimits.js';
 
 /**
  * @param {ChannelWrapper[]} channels
  * @param {import('discord.js').Snowflake[]} defaultChannels
- * @return {SelectMenuBuilder}
+ * @return {import('discord.js').StringSelectMenuBuilder}
  */
 export function channelSelectMenu(channels, defaultChannels = []) {
-    return new SelectMenuBuilder()
-        .setMinValues(1)
-        .setMaxValues(SELECT_MENU_OPTIONS_LIMIT)
+    return new StringSelectMenuBuilder()
         .setOptions(
             /** @type {*} */
             channels

--- a/src/util/util.js
+++ b/src/util/util.js
@@ -81,3 +81,12 @@ export function deepMerge(target, source) {
     }
     return target;
 }
+
+/**
+ * escape a regular expression
+ * @param string
+ * @return {string}
+ */
+export function escapeRegExp(string) {
+    return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}


### PR DESCRIPTION
- use new channel select menus
- make response, priority and punishment duration actually optional for bad-words
- set consistent max length on those properties
- automatically convert "include" and "match" triggers to a regex when the regex type is selected
- Fix punishment corruption caused by edits (#543)