### PR TITLE
New slash command permissions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "modbot",
-  "version": "3.1.2",
+  "version": "3.2.0",
   "description": "Discord Bot for the Aternos Discord server",
   "main": "index.js",
   "type": "module",

--- a/src/bot/Bot.js
+++ b/src/bot/Bot.js
@@ -13,7 +13,7 @@ import MessageDeleteEmbed from '../embeds/MessageDeleteEmbed.js';
 
 export class Bot {
     /**
-     * @type {Client}
+     * @type {import('discord.js').Client}
      */
     #client;
 
@@ -44,6 +44,9 @@ export class Bot {
         });
     }
 
+    /**
+     * @return {import('discord.js').Client}
+     */
     get client() {
         return this.#client;
     }

--- a/src/commands/Command.js
+++ b/src/commands/Command.js
@@ -17,7 +17,8 @@ export default class Command extends ExecutableCommand {
      * Permissions that members need to execute this command by default.
      * Null: no permissions required. Empty bitfield: disabled by default
      *
-     * This is not checked by ModBot and is only used to register commands on discord
+     * For slash commands this is not checked by ModBot and is only used to register commands on Discord
+     * For context menus, buttons and other interactions ModBot emulate Discord's permission system
      * @return {?import('discord.js').PermissionsBitField}
      */
     getDefaultMemberPermissions() {

--- a/src/discord/permissions/SlashCommandPermissionManager.js
+++ b/src/discord/permissions/SlashCommandPermissionManager.js
@@ -1,0 +1,44 @@
+import {RESTJSONErrorCodes} from 'discord.js';
+import SlashCommandPermissionOverrides from './SlashCommandPermissionOverrides.js';
+import bot from '../../bot/Bot.js';
+
+/**
+ * Emulate Discord Slash Command Permissions
+ * @abstract
+ */
+export default class SlashCommandPermissionManager {
+
+    /**
+     * Calculates if a member has the permission to execute a command in a guild
+     * Uses the older V2 Permission system: https://discord.com/developers/docs/change-log#updated-command-permissions
+     * @param {import('discord.js').Interaction<"cached">} interaction
+     * @param {Command} command
+     * @return {Promise<boolean>}
+     */
+    async hasPermission(interaction, command) {
+        throw new Error('Not implemented');
+    }
+
+    /**
+     * fetch the overrides for a command or application
+     * @param {import('discord.js').Interaction<"cached">} interaction
+     * @param {import('discord.js').Snowflake} [commandId] leave empty to fetch global permissions
+     * @return {Promise<SlashCommandPermissionOverrides>}
+     */
+    async fetchOverrides(interaction, commandId = bot.client.user.id) {
+        let overrides = [];
+        try {
+            overrides = await interaction.guild.commands.permissions.fetch({command: commandId});
+
+        }
+        catch (e) {
+            if (e.code === RESTJSONErrorCodes.UnknownApplicationCommandPermissions) {
+                overrides = [];
+            } else {
+                throw e;
+            }
+        }
+
+        return new SlashCommandPermissionOverrides(overrides, interaction.guild, interaction.member, interaction.channel);
+    }
+}

--- a/src/discord/permissions/SlashCommandPermissionManagerV2.js
+++ b/src/discord/permissions/SlashCommandPermissionManagerV2.js
@@ -1,0 +1,85 @@
+import {PermissionFlagsBits} from 'discord.js';
+import SlashCommandPermissionManager from './SlashCommandPermissionManager.js';
+
+export default class SlashCommandPermissionManagerV2 extends SlashCommandPermissionManager {
+    /**
+     * Calculates if a member has the permission to execute a command in a guild
+     * Uses the older V2 Permission system: https://discord.com/developers/docs/change-log#updated-command-permissions
+     * @param {import('discord.js').Interaction<"cached">} interaction
+     * @param {Command} command
+     * @return {Promise<boolean>}
+     */
+    async hasPermission(interaction, command) {
+        if (interaction.memberPermissions.has(PermissionFlagsBits.Administrator)) {
+            return true;
+        }
+
+        if (!interaction.memberPermissions.has(PermissionFlagsBits.UseApplicationCommands)) {
+            return false;
+        }
+
+        // Check permissions for specific command if they exist
+        const commandPermissions = await this.fetchOverrides(interaction, command.id);
+        if (commandPermissions.rawOverrides.length) {
+            return this.hasPermissionInOverrides(commandPermissions);
+        }
+
+        // Fallback to global permissions if they exist
+        const globalPermissions = await this.fetchOverrides(interaction);
+        if (globalPermissions.rawOverrides.length) {
+            return this.hasPermissionInOverrides(globalPermissions);
+        }
+
+        // Fallback to default permissions
+        switch (command.getDefaultMemberPermissions()) {
+            case null:
+                return true;
+            case 0:
+                return false;
+            default:
+                return interaction.memberPermissions.has(command.getDefaultMemberPermissions());
+        }
+    }
+
+    /**
+     * @param {SlashCommandPermissionOverrides} overrides
+     * @return {Promise<?boolean>}
+     */
+    async hasPermissionInOverrides(overrides) {
+        let permission = null;
+
+        // check channel permissions
+        if (overrides.channelOverride) {
+            if (!overrides.channelOverride.permission) {
+                return false;
+            }
+        }
+        else if (overrides.allChannelsOverride) {
+            if (!overrides.allChannelsOverride.permission) {
+                return false;
+            }
+        }
+
+        // Apply permissions for the default role (@everyone).
+        if (overrides.everyoneOverride) {
+            permission = overrides.everyoneOverride.permission;
+        }
+
+        // Apply denies for all additional roles the guild member has at once.
+        if (overrides.memberRoleOverrides.some(override => !override.permission)) {
+            permission = false;
+        }
+
+        // Apply allows for all additional roles the guild member has at once.
+        if (overrides.memberRoleOverrides.some(override => override.permission)) {
+            permission = true;
+        }
+
+        // Apply permissions for the specific guild member if they exist.
+        if (overrides.memberOverride) {
+            permission = overrides.memberOverride.permission;
+        }
+
+        return permission;
+    }
+}

--- a/src/discord/permissions/SlashCommandPermissionManagerV3.js
+++ b/src/discord/permissions/SlashCommandPermissionManagerV3.js
@@ -1,0 +1,157 @@
+import SlashCommandPermissionManager from './SlashCommandPermissionManager.js';
+
+export default class SlashCommandPermissionManagerV3 extends SlashCommandPermissionManager {
+    /**
+     * Check if the user has permission to execute the command.
+     * This method uses the new V3 Permissions.
+     * Reference: https://discord.com/developers/docs/change-log#upcoming-application-command-permission-changes
+     * Flowchart: ![](https://media.discordapp.net/attachments/697138785317814292/1042878162901672048/flowchart-for-new-permissions.png)
+     * @param {import('discord.js').Interaction<"cached">} interaction
+     * @param {Command} command
+     * @return {Promise<boolean>}
+     */
+    async hasPermission(interaction, command) {
+        const commandOverrides = await this.fetchOverrides(interaction, command.id);
+        const appOverrides = await this.fetchOverrides(interaction);
+        return this.hasCommandLevelChannelPermission(commandOverrides, appOverrides, interaction, command);
+    }
+
+    /**
+     * Check if the user has permission to execute this command in context.
+     * Check channel permissions for this command then fall back to other relevant checks.
+     * Implements the upper block of "(1) Channel permissions" of the flowchart.
+     * @param {SlashCommandPermissionOverrides} commandOverrides
+     * @param {SlashCommandPermissionOverrides} appOverrides
+     * @param {import('discord.js').Interaction<"cached">} interaction
+     * @param {Command} command
+     * @return {Promise<boolean>}
+     */
+    async hasCommandLevelChannelPermission(commandOverrides, appOverrides, interaction, command) {
+        if (commandOverrides.channelOverride) {
+            if (!commandOverrides.channelOverride.permission) {
+                return false;
+            }
+            return this.hasCommandLevelUserRolePermission(commandOverrides, appOverrides, interaction, command);
+        }
+        else {
+            if (!commandOverrides.allChannelsOverride) {
+                return this.hasAppLevelChannelPermission(commandOverrides, appOverrides, interaction, command);
+            }
+            else {
+                if (!commandOverrides.allChannelsOverride.permission) {
+                    return false;
+                }
+                return this.hasCommandLevelUserRolePermission(commandOverrides, appOverrides, interaction, command);
+            }
+        }
+    }
+
+    /**
+     * Check if the user has permission to execute this command in context.
+     * Check channel permissions for the app then fall back to other relevant checks.
+     * Implements the lower block of "(1) Channel permissions" of the flowchart.
+     * @param {SlashCommandPermissionOverrides} commandOverrides
+     * @param {SlashCommandPermissionOverrides} appOverrides
+     * @param {import('discord.js').Interaction<"cached">} interaction
+     * @param {Command} command
+     * @return {Promise<boolean>}
+     */
+    async hasAppLevelChannelPermission(commandOverrides, appOverrides, interaction, command) {
+        if (appOverrides.channelOverride) {
+            if (!appOverrides.channelOverride.permission) {
+                return false;
+            }
+            return this.hasCommandLevelUserRolePermission(commandOverrides, appOverrides, interaction, command);
+        }
+        else {
+            if (appOverrides.allChannelsOverride && !appOverrides.allChannelsOverride.permission) {
+                return false;
+            }
+            return this.hasCommandLevelUserRolePermission(commandOverrides, appOverrides, interaction, command);
+        }
+    }
+
+    /**
+     * Check if the user has permission to execute this command in context.
+     * Check user/role permissions for this command then fall back to other relevant checks.
+     * Implements the upper block of "(2) User/role permissions" of the flowchart.
+     * @param {SlashCommandPermissionOverrides} commandOverrides
+     * @param {SlashCommandPermissionOverrides} appOverrides
+     * @param {import('discord.js').Interaction<"cached">} interaction
+     * @param {Command} command
+     * @return {Promise<boolean>}
+     */
+    async hasCommandLevelUserRolePermission(commandOverrides, appOverrides, interaction, command) {
+        if (commandOverrides.memberOverride) {
+            return commandOverrides.memberOverride.permission;
+        }
+
+        if (commandOverrides.memberRoleOverrides.length) {
+            return commandOverrides.memberRoleOverrides.some(roleOverride => roleOverride.permission);
+        }
+
+        if (commandOverrides.everyoneOverride) {
+            return commandOverrides.everyoneOverride.permission;
+        }
+
+        return this.hasAppLevelUserRolePermission(commandOverrides, appOverrides, interaction, command);
+    }
+
+    /**
+     * Check if the user has permission to execute this command in context.
+     * Check user/role permissions for this app then fall back to other relevant checks.
+     * Implements the lower block of "(2) User/role permissions" of the flowchart.
+     * @param {SlashCommandPermissionOverrides} commandOverrides
+     * @param {SlashCommandPermissionOverrides} appOverrides
+     * @param {import('discord.js').Interaction<"cached">} interaction
+     * @param {Command} command
+     * @return {Promise<boolean>}
+     */
+    async hasAppLevelUserRolePermission(commandOverrides, appOverrides, interaction, command) {
+        if (appOverrides.memberOverride) {
+            if (!appOverrides.memberOverride.permission) {
+                return false;
+            }
+            return this.hasDefaultPermission(commandOverrides, appOverrides, interaction, command);
+        }
+
+        if (appOverrides.memberRoleOverrides.length) {
+            if (!appOverrides.memberRoleOverrides.some(roleOverride => roleOverride.permission)) {
+                return false;
+            }
+            return this.hasDefaultPermission(commandOverrides, appOverrides, interaction, command);
+        }
+
+        if (appOverrides.everyoneOverride) {
+            if (!appOverrides.everyoneOverride.permission) {
+                return false;
+            }
+            return this.hasDefaultPermission(commandOverrides, appOverrides, interaction, command);
+        }
+
+        return this.hasDefaultPermission(commandOverrides, appOverrides, interaction, command);
+    }
+
+    /**
+     * Check if the user has permission to execute this command in context.
+     * Check default permissions for this command.
+     * Implements the block "(3) Default member permissions" of the flowchart.
+     * @param {SlashCommandPermissionOverrides} commandOverrides
+     * @param {SlashCommandPermissionOverrides} appOverrides
+     * @param {import('discord.js').Interaction<"cached">} interaction
+     * @param {Command} command
+     * @return {Promise<boolean>}
+     */
+    async hasDefaultPermission(commandOverrides, appOverrides, interaction, command) {
+        switch (command.getDefaultMemberPermissions()) {
+            case null:
+                return true;
+
+            case 0:
+                return false;
+
+            default:
+                return interaction.member.permissions.has(command.getDefaultMemberPermissions());
+        }
+    }
+}

--- a/src/discord/permissions/SlashCommandPermissionManagers.js
+++ b/src/discord/permissions/SlashCommandPermissionManagers.js
@@ -1,0 +1,20 @@
+import SlashCommandPermissionManagerV2 from './SlashCommandPermissionManagerV2.js';
+import SlashCommandPermissionManagerV3 from './SlashCommandPermissionManagerV3.js';
+import {GuildFeature} from 'discord.js';
+
+export default class SlashCommandPermissionManagers {
+    static V2 = new SlashCommandPermissionManagerV2();
+    static V3 = new SlashCommandPermissionManagerV3();
+
+    /**
+     * @param {import('discord.js').Interaction<"cached">} interaction
+     * @return {SlashCommandPermissionManagerV2|SlashCommandPermissionManagerV3}
+     */
+    static getManager(interaction) {
+        if (interaction.guild.features.includes(GuildFeature.ApplicationCommandPermissionsV2)) {
+            return this.V2;
+        } else {
+            return this.V3;
+        }
+    }
+}

--- a/src/discord/permissions/SlashCommandPermissionOverrides.js
+++ b/src/discord/permissions/SlashCommandPermissionOverrides.js
@@ -53,7 +53,7 @@ export default class SlashCommandPermissionOverrides {
 
     /**
      * get the overrides for the @everyone role
-     * @return {?import('discord.js').ApplicationCommandPermissions} // TODO: not null?
+     * @return {?import('discord.js').ApplicationCommandPermissions}
      */
     get everyoneOverride() {
         return this.roleOverrides.find(override => override.id === this.#guild.id) ?? null;

--- a/src/discord/permissions/SlashCommandPermissionOverrides.js
+++ b/src/discord/permissions/SlashCommandPermissionOverrides.js
@@ -1,0 +1,110 @@
+import {ApplicationCommandPermissionType} from 'discord.js';
+
+export default class SlashCommandPermissionOverrides {
+    /**
+     * @type {import('discord.js').ApplicationCommandPermissions[]}
+     */
+    #overrides = [];
+
+    /**
+     * @type {import('discord.js').Guild}
+     */
+    #guild;
+
+    /**
+     * @type {import('discord.js').GuildMember}
+     */
+    #member;
+
+    /**
+     * @type {import('discord.js').Channel}
+     */
+    #channel;
+
+    /**
+     *
+     * @param {import('discord.js').ApplicationCommandPermissions[]} overrides
+     * @param {import('discord.js').Guild} guild
+     * @param {import('discord.js').GuildMember} member
+     * @param {import('discord.js').Channel} channel
+     */
+    constructor(overrides, guild, member, channel) {
+        this.#overrides = overrides;
+        this.#guild = guild;
+        this.#member = member;
+        this.#channel = channel;
+    }
+
+    /**
+     * get the raw overrides
+     * @return {import('discord.js').ApplicationCommandPermissions[]}
+     */
+    get rawOverrides() {
+        return this.#overrides;
+    }
+
+    /**
+     * get all role overrides
+     * @return {import('discord.js').ApplicationCommandPermissions[]}
+     */
+    get roleOverrides() {
+        return this.#overrides.filter(override => override.type === ApplicationCommandPermissionType.Role);
+    }
+
+    /**
+     * get the overrides for the @everyone role
+     * @return {?import('discord.js').ApplicationCommandPermissions} // TODO: not null?
+     */
+    get everyoneOverride() {
+        return this.roleOverrides.find(override => override.id === this.#guild.id) ?? null;
+    }
+
+    /**
+     * get the overrides for all roles this member has
+     * @return {import('discord.js').ApplicationCommandPermissions[]}
+     */
+    get memberRoleOverrides() {
+        return this.roleOverrides.filter(override => this.#member.roles.resolve(override.id));
+    }
+
+    /**
+     * get the overrides for all members
+     * @return {import('discord.js').ApplicationCommandPermissions[]}
+     */
+    get memberOverrides() {
+        return this.#overrides.filter(override => override.type === ApplicationCommandPermissionType.User);
+    }
+
+    /**
+     * get the override value for a single member
+     * @return {?import('discord.js').ApplicationCommandPermissions}
+     */
+    get memberOverride() {
+        return this.memberOverrides.find(override => override.id === this.#member.id) ?? null;
+    }
+
+    /**
+     * get the overrides for all channels
+     * @return {import('discord.js').ApplicationCommandPermissions[]}
+     */
+    get channelOverrides() {
+        return this.#overrides.filter(override => override.type === ApplicationCommandPermissionType.Channel);
+    }
+
+    /**
+     * get the default channel override value
+     * @return {?import('discord.js').ApplicationCommandPermissions}
+     */
+    get allChannelsOverride() {
+        // https://discord.com/developers/docs/interactions/application-commands#application-command-permissions-object-application-command-permissions-constants
+        return this.channelOverrides.find(override => override.id === (BigInt(this.#guild.id) - 1n).toString()) ?? null;
+    }
+
+    /**
+     * get the override value for a single channel
+     * @return {?import('discord.js').ApplicationCommandPermissions}
+     */
+    get channelOverride() {
+        return this.channelOverrides.find(override => override.id === this.#channel.id) ?? null;
+    }
+}


### PR DESCRIPTION
This PR adds support for using the new V3 Slash Command Permission system.
Reference: https://discord.com/developers/docs/change-log#upcoming-application-command-permission-changes
Flowchart: 
![Flowchart](https://media.discordapp.net/attachments/697138785317814292/1042878162901672048/flowchart-for-new-permissions.png)

Guilds with the "ApplicationCommandPermissionsV2" feature flag will continue to use the old V2 format.
Once the feature rolls out, this flag will be removed from guilds when they migrate to it.