### PR TITLE
Hopefully fix filter

### DIFF
--- a/src/commands/guild/PurgeCommand.js
+++ b/src/commands/guild/PurgeCommand.js
@@ -74,7 +74,7 @@ export default class PurgeCommand extends Command {
                     return false;
                 }
 
-                return !(content && this.matches(message, s => s.toLowerCase().includes(content)));
+                return (content && this.matches(message, s => s.toLowerCase().includes(content)));
             });
 
         if (messages.size === 0) {


### PR DESCRIPTION
Should combat the issue where /purge `content:string` would delete everything except messages containing `string`.