### PR TITLE
Adjustment of default safeSearch likelihood according to Google recommendations and address current overzealous behaviour

### DIFF
--- a/src/settings/GuildSettings.js
+++ b/src/settings/GuildSettings.js
@@ -66,7 +66,7 @@ export default class GuildSettings extends Settings {
         safeSearch: {
             enabled: true,
             strikes: 1,
-            likelihood: 1,
+            likelihood: 2,
         },
     };
 


### PR DESCRIPTION
This PR is made in response to ModBot being noticeably overzealous in its detection and automatic removal of inappropriate images. Investigation revealed that the default likelihood threshold is set to 1 (corresponding to LIKELY).

Google states
> In situations where you want to avoid false positives and flag images that you are very sure contain pornographic content, you would remove only images that the API identifies as VERY_LIKELY. If you aren’t as concerned with false positives and want to be on the safe side, you would flag and review all images that return POSSIBLE and above. Ultimately, your use case will determine how you handle the classifier’s response.
(Sara Robinson, Filtering inappropriate content with the Cloud Vision API)

Stating that for all labels, including and above POSSIBLE, you would flag and review images. While reserving automatic removals for VERY_LIKELY in order to avoid false positives.

This change would not only better with the, albeit-not-absolute, recommendations set forth by Robinson but most importantly address the currently-present overzealous behaviour.

Possible partial invalidity: The discussed behaviour has been observed in the Aternos Discord server, and works under the assumption that the settings for that guild have not been modified to further lower the threshold.