### PR TITLE
Add a cooldown for tags (auto-responses) per-channel cooldowns

### DIFF
--- a/src/events/discord/messageCreate/AutoResponseEventListener.js
+++ b/src/events/discord/messageCreate/AutoResponseEventListener.js
@@ -26,12 +26,12 @@ export default class AutoResponseEventListener extends MessageCreateEventListene
             const response = triggered[Math.floor(Math.random() * triggered.length)];
             if (recentAutoresponse.has(message.channel.id)) { // checks if a tag has been used in this channel in the last <cooldown time>
             	message.react('⏲️') // react with timer emoji to show that there is currently a cooldown active
-    		} else {
-		    await message.reply({content: response.response});
-        	    recentAutoresponse.add(message.channel.id);
-        	    setTimeout(() => {
-          	        recentAutoresponse.delete(message.channel.id); // removes the cooldown after <cooldown time>
-        	    }, tagCooldown);
+    	    } else {
+		await message.reply({content: response.response});
+        	recentAutoresponse.add(message.channel.id);
+        	setTimeout(() => {
+          	    recentAutoresponse.delete(message.channel.id); // removes the cooldown after <cooldown time>
+        	}, tagCooldown);
     	    }
         }
     }

--- a/src/events/discord/messageCreate/AutoResponseEventListener.js
+++ b/src/events/discord/messageCreate/AutoResponseEventListener.js
@@ -1,6 +1,8 @@
 import MessageCreateEventListener from './MessageCreateEventListener.js';
 import AutoResponse from '../../../database/AutoResponse.js';
 import {ThreadChannel} from 'discord.js';
+const recentAutoresponse = new Set(); // creates a new Set for cooldowns
+
 
 export default class AutoResponseEventListener extends MessageCreateEventListener {
 
@@ -18,9 +20,19 @@ export default class AutoResponseEventListener extends MessageCreateEventListene
         const responses = (await AutoResponse.get(channel.id, message.guild.id)).values();
         const triggered = Array.from(responses).filter(response => response.matches(message));
 
+		let tagCooldown = 10000 //10 seconds, e.g. 5000 = 5 seconds
+        
         if (triggered.length) {
             const response = triggered[Math.floor(Math.random() * triggered.length)];
-            await message.reply({content: response.response});
+            if (recentAutoresponse.has(message.channel.id)) { // checks if a tag has been used in this channel in the last <cooldown time>
+            	message.react('⏲️') // react with timer emoji to show that there is currently a cooldown active
+    		} else {
+				await message.reply({content: response.response});
+        		recentAutoresponse.add(message.channel.id);
+        		setTimeout(() => {
+          			recentAutoresponse.delete(message.channel.id); // removes the cooldown after <cooldown time>
+        		}, tagCooldown);
+    		}
         }
     }
 }

--- a/src/events/discord/messageCreate/AutoResponseEventListener.js
+++ b/src/events/discord/messageCreate/AutoResponseEventListener.js
@@ -20,19 +20,19 @@ export default class AutoResponseEventListener extends MessageCreateEventListene
         const responses = (await AutoResponse.get(channel.id, message.guild.id)).values();
         const triggered = Array.from(responses).filter(response => response.matches(message));
 
-		let tagCooldown = 10000 //10 seconds, e.g. 5000 = 5 seconds
+	let tagCooldown = 10000 //10 seconds, e.g. 5000 = 5 seconds
         
         if (triggered.length) {
             const response = triggered[Math.floor(Math.random() * triggered.length)];
             if (recentAutoresponse.has(message.channel.id)) { // checks if a tag has been used in this channel in the last <cooldown time>
             	message.react('⏲️') // react with timer emoji to show that there is currently a cooldown active
     		} else {
-				await message.reply({content: response.response});
-        		recentAutoresponse.add(message.channel.id);
-        		setTimeout(() => {
-          			recentAutoresponse.delete(message.channel.id); // removes the cooldown after <cooldown time>
-        		}, tagCooldown);
-    		}
+		    await message.reply({content: response.response});
+        	    recentAutoresponse.add(message.channel.id);
+        	    setTimeout(() => {
+          	        recentAutoresponse.delete(message.channel.id); // removes the cooldown after <cooldown time>
+        	    }, tagCooldown);
+    	    }
         }
     }
 }


### PR DESCRIPTION
This modification adds a cooldown per auto-response (tags) per-channel to make sure that if multiple people execute a tag all at once, then the bot doesn't send it twice. It'll only respond to one tag.
E.G. If a user asks, "how do I appeal?", then four people execute !appeal to show the user what to do, that message is sent 4 times. But with this modification, the bot only replies to one, and reacts with the timer emoji for the rest.